### PR TITLE
log successes

### DIFF
--- a/funsearch/models.py
+++ b/funsearch/models.py
@@ -282,7 +282,7 @@ class LLMModel:
                 end = time.time()
                 logging.debug(f"prompt:end:{self.model}:{self.id}:{self.counter}:{attempt}:{end-start:.3f}")
                 if chat_response is not None:
-                    logging.debug(f"prompt:success:{self.model}:{self.id}:{self.counter}:{attempt}:{end-begin:.3f}",)
+                    logging.info(f"prompt:success:{self.model}:{self.id}:{self.counter}:{attempt}:{end-begin:.3f}",)
                     self.counter += 1
                     return chat_response,usage_stats
                 logging.warning(f"prompt:error-empty:{self.model}:{self.id}:{self.counter}:{attempt}:{end-start:.3f}")


### PR DESCRIPTION
This change makes successes logged at info level rather than debug.  Given that we are typically going to see an HTTP message for every sample, I don't think this will signficantly change the total amount of output and I think it is helpful (and reassuring) for users to see this.